### PR TITLE
feat: Apache server status page

### DIFF
--- a/.ddev/apache/server-status.conf
+++ b/.ddev/apache/server-status.conf
@@ -1,0 +1,17 @@
+# This page exposes Apache server statics at :8080/server-status
+# NOTE: This information is considered sensitive and should NOT be exposed in a production environment.
+# #ddev-generated
+Listen 8080
+
+<VirtualHost *:8080>
+    DocumentRoot /var/www/html
+
+    <Location "/server-status">
+        SetHandler server-status
+        Require all granted
+    </Location>
+
+    # Optional: Logging
+    ErrorLog /var/log/apache2/server-status-error.log
+    CustomLog /var/log/apache2/server-status-access.log combined
+</VirtualHost>

--- a/.ddev/config.webserver.yaml
+++ b/.ddev/config.webserver.yaml
@@ -1,0 +1,8 @@
+# Expose port 8080
+# Visit `:8080/service-status` to see Apache Server Status.
+# @See `.ddev/apache/server-status.config`
+web_extra_exposed_ports:
+  - name: webserver
+    container_port: 8080
+    http_port: 8081
+    https_port: 8080

--- a/README.md
+++ b/README.md
@@ -3,4 +3,43 @@
 ## Overview
 
 This project is a basic DDEV apache webserver setup.
+It is designed to be used as a playground.
 
+## Server status
+
+1. Ensure `status` module is enabled
+
+    ```shell
+    # Enable module
+    a2enmod status
+
+    # List all modules
+    a2query -m
+    ```
+
+2. Add endpoint
+
+    ```conf
+    Listen 8080
+
+    <VirtualHost *:8080>
+        DocumentRoot /var/www/html
+
+        <Location "/server-status">
+            SetHandler server-status
+            Require all granted
+        </Location>
+
+        # Optional: Logging
+        ErrorLog /var/log/apache2/server-status-error.log
+        CustomLog /var/log/apache2/server-status-access.log combined
+    </VirtualHost>
+    ```
+
+3. Restart Apache to apply changes.
+
+    ```shell
+    sudo service apache2 restart
+    ```
+
+4. Visit `:8080/server-status` to see status data.


### PR DESCRIPTION
Fix: Expose Apache Server Status Endpoint

This pull request introduces a new endpoint to expose Apache server status, enabling developers to monitor server performance and troubleshoot issues more effectively.

**Problem:**

Currently, there is no easy way to access Apache server status information within the DDEV environment. This lack of visibility makes it difficult to diagnose performance bottlenecks, track resource usage, and generally understand the health of the webserver.

**Solution:**

This pull request implements the following changes:

*   **`.ddev/apache/server-status.conf`:** Creates a new Apache configuration file that defines a virtual host listening on port 8080. This virtual host exposes the `/server-status` endpoint, which is configured to use the `server-status` handler.  It allows access to this endpoint from any source (`Require all granted`).  It also adds optional logging for the server-status endpoint.
*   **`.ddev/config.webserver.yaml`:** Adds a `web_extra_exposed_ports` section to expose port 8080 of the webserver container, mapping it to host port 8080 for HTTPS and 8081 for HTTP. This makes the `server-status` endpoint accessible from the host machine.
*   **`README.md`:** Adds instructions on how to verify that the `status` module is enabled, and to access the `/server-status` endpoint.

**Benefits:**

*   Provides developers with real-time insights into Apache server performance.
*   Simplifies troubleshooting and debugging of webserver issues.
*   Enhances the overall development experience by providing greater visibility into the webserver environment.

**Manual Testing Steps:**

1.  **Apply the changes:**  Checkout this branch.
2.  **Start DDEV:** Run `ddev start`.
3.  **Verify port mapping:** Run `ddev describe` and confirm that port 8080 is mapped to the web container.
4.  **Access server-status:** Open your web browser and navigate to `https://<ddev-site-name>.ddev.site:8080/server-status` or `http://<ddev-site-name>.ddev.site:8081/server-status`. Replace `<ddev-site-name>` with the name of your DDEV project. You should see the Apache server status page.
5.  **Verify Module enabled (Optional):**  `ddev ssh`, then run `apache2ctl -M` or `a2query -m` to ensure the `status_module` is enabled.
6.  **Examine logs (Optional):** `ddev ssh` and then `tail -f /var/log/apache2/server-status-access.log` and `tail -f /var/log/apache2/server-status-error.log` while refreshing the `/server-status` page in your browser.  You should see activity in the access log.

These steps will confirm that the changes are working as expected and that the Apache server status endpoint is accessible.